### PR TITLE
Fix second derivative notation.

### DIFF
--- a/finite-volume/finite-volume.tex
+++ b/finite-volume/finite-volume.tex
@@ -259,7 +259,7 @@ For example, a second derivative can be discretized as:
 \begin{equation}
 \left . \frac{d^2 f}{dx^2} \right |_i = \frac{f_{i+1} - 2 f_i + f_{i-1}}{\Delta x^2}
 \end{equation}
-The stencil on the righthand size encompasses 3 zones.
+The stencil on the righthand side encompasses 3 zones.
 
 \subsection{Conservation}
 

--- a/finite-volume/finite-volume.tex
+++ b/finite-volume/finite-volume.tex
@@ -257,7 +257,7 @@ either side of zone $i$ we reach when computing our approximation.
 
 For example, a second derivative can be discretized as:
 \begin{equation}
-\left . \frac{df}{dx} \right |_i = \frac{f_{i+1} - 2 f_i + f_{i-1}}{\Delta x^2}
+\left . \frac{d^2 f}{dx^2} \right |_i = \frac{f_{i+1} - 2 f_i + f_{i-1}}{\Delta x^2}
 \end{equation}
 The stencil on the righthand size encompasses 3 zones.
 


### PR DESCRIPTION
The second derivative discretization example equation uses first derivative notation on the left hand side, this fixes it.