### PR TITLE
Minor fixes in advection, intro sections

### DIFF
--- a/advection/advection.tex
+++ b/advection/advection.tex
@@ -297,12 +297,11 @@ discretization.  Here our upwind method would appear as:
 \begin{equation}
 \frac{a^{n+1}_i - a^n_i}{\Delta t} = -u \frac{a^{n+1}_i - a^{n+1}_{i-1}}{\Delta x}
 \end{equation}
-We can write this as a linear system with coupled equations:
+The only change here is that the righthand side is evaluated at the new timelevel,
+$n+1$. We can write this as a linear system with coupled equations:
 \begin{equation}
 -\cfl a^{n+1}_{i-1} + (1 + \cfl) a^{n+1}_i = a_i^n
 \end{equation}
-The only change here is that the righthand side is evaluated at the new timelevel,
-$n+1$.
 
 If we use periodic boundary conditions, then point $0$ and $N-1$ are
 identical, so we only need to update one of these.  Taking $u_0^{n+1} = u_{N-1}^{n+1}$, our system in matrix form appears as:

--- a/advection/advection.tex
+++ b/advection/advection.tex
@@ -720,7 +720,7 @@ can be found in \cite{toro:1997,leveque:2002}.
   $i+1$, the slopes are limited slightly, so as not to overshoot or
   undershoot the neighboring cell value.  Cell $i-1$ is not limited at
   all, whereas cells $i-2$, and $i+2$ are fully limited---the slope is
-  set to 0---these are extrema.}
+  set to $0$---these are extrema.}
 \end{figure}
 
 A popular extension of the MC limiter is the $4^\mathrm{th}$-order MC

--- a/advection/advection.tex
+++ b/advection/advection.tex
@@ -304,7 +304,7 @@ $n+1$. We can write this as a linear system with coupled equations:
 \end{equation}
 
 If we use periodic boundary conditions, then point $0$ and $N-1$ are
-identical, so we only need to update one of these.  Taking $u_0^{n+1} = u_{N-1}^{n+1}$, our system in matrix form appears as:
+identical, so we only need to update one of these.  Taking $a_0^{n+1} = a_{N-1}^{n+1}$, our system in matrix form appears as:
 \begin{equation}
 \renewcommand{\arraystretch}{1.5}
 \left ( \begin{array}{ccccccc} 
@@ -319,24 +319,24 @@ identical, so we only need to update one of these.  Taking $u_0^{n+1} = u_{N-1}^
 \right )
 %
 \left ( \begin{array}{c}
-u_1^{n+1} \\
-u_2^{n+1} \\
-u_3^{n+1} \\
-u_4^{n+1} \\
+a_1^{n+1} \\
+a_2^{n+1} \\
+a_3^{n+1} \\
+a_4^{n+1} \\
 \vdots \\
-u_{N-2}^{n+1} \\
-u_{N-1}^{n+1} 
+a_{N-2}^{n+1} \\
+a_{N-1}^{n+1}
 \end{array}
 \right )
 =
 \left ( \begin{array}{c}
-u_1^{n} \\
-u_2^{n} \\
-u_3^{n} \\
-u_4^{n} \\
+a_1^{n} \\
+a_2^{n} \\
+a_3^{n} \\
+a_4^{n} \\
 \vdots \\
-u_{N-2}^{n} \\
-u_{N-1}^{n} 
+a_{N-2}^{n} \\
+a_{N-1}^{n}
 \end{array}
 \right )
 \end{equation}

--- a/intro/intro.tex
+++ b/intro/intro.tex
@@ -626,7 +626,7 @@ Using this approximation, we can expand the righthand side vector,
 {\bf f}(t^{n+1},{\bf y}^{n+1}) = {\bf f}(t^{n+1}, {\bf y}^{n+1}_0) +
      \left . \frac{\partial {\bf f}}{\partial {\bf y}} \right |_0 \Delta {\bf y}_0 + \ldots
 \end{equation}
-Here we recognize the Jacobin matrix, ${\bf J} \equiv \partial {\bf
+Here we recognize the Jacobian matrix, ${\bf J} \equiv \partial {\bf
   f}/\partial {\bf y}$,
 \begin{equation}
 \renewcommand\arraystretch{1.5}


### PR DESCRIPTION
This PR makes some minor fixes to the advection and intro:

- Fix Jacobian spelling in intro
- Relocate a sentence in implicit time advection section for clarity.
- Change variable notation from $u$ to $a$ in matrix equation in implicit time advection section to match the variable convention in the rest of this chapter.
- Fix a typesetting bug in the caption for Figure 4.12 where the 0 preceding a triple dash was rendered to look like a lowercase "o".