### PR TITLE
Minor corrections

### DIFF
--- a/advection/advection-higherorder.tex
+++ b/advection/advection-higherorder.tex
@@ -896,7 +896,7 @@ these methods $\cfl \lesssim 1$.  This is usually more restrictive than
 Eq.~\ref{eq:adv:timestep:multid}.
 
 For the CTU method described above, \cite{colella:1990} argues that
-the inclusion of the transverse information removes some of the some
+the inclusion of the transverse information removes some
 of the instability inherent in simpler schemes, allowing for a larger
 timestep, restricted by Eq.~\ref{eq:adv:timestep:multid}.
 

--- a/advection/advection-higherorder.tex
+++ b/advection/advection-higherorder.tex
@@ -425,9 +425,9 @@ is
  &=& a_{i} - \frac{1}{2} \Delta a_{i} \cfl
 \end{eqnarray}
 
-The final part of the R-E-A procedure is to average the over the 
+The final part of the R-E-A procedure is to average over the 
 advected profiles in the new cell.  The weighted average of the
-amount brought in from the left of the interface and that that remains
+amount brought in from the left of the interface and that remains
 in the cell is
 \begin{align}
 a_i^{n+1} &= \cfl \mathcal{I}_< + (1 - \cfl) \mathcal{I}_>  \\

--- a/advection/advection-higherorder.tex
+++ b/advection/advection-higherorder.tex
@@ -355,7 +355,7 @@ Eq. 191).
 
 \begin{exercise}[Limiting and reduction in order-of-accuracy]
 {Show analytically that if you fully limit the slopes
-  (i.e.\ set $\partial a/\partial x |_i = 0$, that the second-order
+	(i.e.\ set $\partial a/\partial x |_i = 0$),then the second-order
   method reduces to precisely our first-order finite-difference discretization,
   Eq.~\ref{eq:fo}.  }
 \end{exercise}


### PR DESCRIPTION
1) syntax error in exercise 5.3, there was a parenthesis missing

2) two syntax errors in the description of the R-E-A procedure (5.2.2)

3) syntax error in the description of the time stepper limiter multi dimensional (5.4.3)

Additionally: in 5.3 Method of Lines approach there is a wrong reference to an equation \ref{eq:adv:fvadv} which results in a question mark. I was not able to trace back what equation you meant...

Thanks for the book, I found it really helpful! 