### PR TITLE
fix ref to eq adv:eq:fvadv, was eq:adv:fvadv § 5.3

### DIFF
--- a/advection/advection-higherorder.tex
+++ b/advection/advection-higherorder.tex
@@ -508,7 +508,7 @@ tophat profiles with several different limiters.
 In the above constructions, we computed a time-centered flux by
 predicting the interface state to the half-time (by Taylor-expanding
 in time through $\Delta t /2$).  Instead, we can recognize that with
-the spatial discretization done in Eq.~\ref{eq:adv:fvadv}, we are left
+the spatial discretization done in Eq.~\ref{adv:eq:fvadv}, we are left
 with an ordinary differential equation in time that can then be solved
 using standard ODE techniques.
 


### PR DESCRIPTION
There was reference to an equation that was mistyped in chapter 5.3 (method of lines). It was eq:adv:fvadv, should have been adv:eq:fvadv. I cannot compile on my machine but I believe it should work out. 