### PR TITLE
removes hypen between right and eigenvector, now consistent 

### DIFF
--- a/Euler/Euler-theory.tex
+++ b/Euler/Euler-theory.tex
@@ -325,7 +325,7 @@ for the fact that in a nonlinear system, $\Lb = \Lb(\qb)$).  The
 characteristic form of the equations says that each of the waves will
 carry its respective jump, $\Delta \wb$.  Since $d\qb = \Lb^{-1}d\wb = \Rb d\wb$,
 the jump in the primitive variable across each wave is proportional to
-the right-eigenvector associated with that wave.  So, for example,
+the right eigenvector associated with that wave.  So, for example,
 since $\rb^\evz$ is only non-zero for the density element (see
 Eq.~\ref{eq:euler:primRevs}), this then means that only density jumps
 across the $\lambda^\evz = u$ wave---pressure and velocity are

--- a/Euler/Euler-theory.tex
+++ b/Euler/Euler-theory.tex
@@ -328,7 +328,7 @@ the jump in the primitive variable across each wave is proportional to
 the right eigenvector associated with that wave.  So, for example,
 since $\rb^\evz$ is only non-zero for the density element (see
 Eq.~\ref{eq:euler:primRevs}), this then means that only density jumps
-across the $\lambda^\evz = u$ wave---pressure and velocity are
+across the $\lambda^\evz = u$ wave, while pressure and velocity are
 constant across this wave (see for example, Toro~\cite{toro:1997},
 Ch.\ 2, 3 or LeVeque~\cite{leveque:2002} for a thorough discussion).
 


### PR DESCRIPTION
removes hypen between right-eigenvector, now consistent with the rest of the book, where it's always without hypen